### PR TITLE
feat: Show close reason after disconnect & close gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,7 +1905,7 @@ checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 [[package]]
 name = "iroh"
 version = "0.30.0"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#5aba17efacc348bb658310d184159b77a65df7f2"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#870c76edebe92fe06effa774c25677da43589351"
 dependencies = [
  "aead",
  "anyhow",
@@ -1985,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "0.30.0"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#5aba17efacc348bb658310d184159b77a65df7f2"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#870c76edebe92fe06effa774c25677da43589351"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "iroh-net-report"
 version = "0.30.0"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#5aba17efacc348bb658310d184159b77a65df7f2"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#870c76edebe92fe06effa774c25677da43589351"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2137,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "0.30.0"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#5aba17efacc348bb658310d184159b77a65df7f2"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#870c76edebe92fe06effa774c25677da43589351"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ iroh-base = "0.30.0"
 url = "2.5.2"
 
 [patch.crates-io]
-iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main"}
+iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
 iroh-relay = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
 # iroh-metrics = { git = "https://github.com/n0-computer/iroh.git", branch = "main"}
 # portmapper = { git = "https://github.com/n0-computer/net-tools.git", branch = "main"}
-iroh-net-report = { git = "https://github.com/n0-computer/iroh.git", branch = "main"}
+iroh-net-report = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -478,7 +478,7 @@ Ipv6:
 
 /// Sends, receives and echoes data in a connection.
 async fn active_side(
-    connection: Connection,
+    connection: &Connection,
     config: &TestConfig,
     gui: Option<&Gui>,
 ) -> anyhow::Result<()> {
@@ -598,7 +598,7 @@ async fn recv_test(
 }
 
 /// Accepts connections and answers requests (echo, drain or send) as passive side.
-async fn passive_side(gui: Gui, connection: Connection) -> anyhow::Result<()> {
+async fn passive_side(gui: Gui, connection: &Connection) -> anyhow::Result<()> {
     let conn = connection.clone();
     let accept_loop = async move {
         let result = loop {
@@ -692,27 +692,44 @@ async fn connect(
 ) -> anyhow::Result<()> {
     let endpoint = make_endpoint(secret_key, relay_map, discovery).await?;
 
-    tracing::info!("dialing {:?}", node_id);
-    let node_addr = NodeAddr::from_parts(node_id, relay_url, direct_addresses);
-    let conn = endpoint.connect(node_addr, &DR_RELAY_ALPN).await;
-    match conn {
-        Ok(connection) => {
-            let maybe_conn_type = endpoint.conn_type(node_id);
-            let gui = Gui::new(endpoint, node_id);
-            if let Ok(conn_type) = maybe_conn_type {
-                log_connection_changes(gui.mp.clone(), node_id, conn_type);
-            }
+    futures_lite::future::race(close_endpoint_on_ctrl_c(endpoint.clone()), async move {
+        tracing::info!("dialing {:?}", node_id);
+        let node_addr = NodeAddr::from_parts(node_id, relay_url, direct_addresses);
+        let conn = endpoint.connect(node_addr, &DR_RELAY_ALPN).await;
+        match conn {
+            Ok(connection) => {
+                let maybe_conn_type = endpoint.conn_type(node_id);
+                let gui = Gui::new(endpoint, node_id);
+                if let Ok(conn_type) = maybe_conn_type {
+                    log_connection_changes(gui.mp.clone(), node_id, conn_type);
+                }
 
-            if let Err(cause) = passive_side(gui, connection).await {
-                eprintln!("error handling connection: {cause}");
+                let close_reason = connection
+                    .close_reason()
+                    .map(|e| format!(" (reason: {})", e.to_string()))
+                    .unwrap_or_default();
+
+                if let Err(cause) = passive_side(gui, &connection).await {
+                    eprintln!("error handling connection: {cause}{close_reason}");
+                } else {
+                    eprintln!("Connection closed{close_reason}");
+                }
+            }
+            Err(cause) => {
+                eprintln!("unable to connect to {node_id}: {cause}");
             }
         }
-        Err(cause) => {
-            eprintln!("unable to connect to {node_id}: {cause}");
-        }
-    }
+    })
+    .await;
 
     Ok(())
+}
+
+async fn close_endpoint_on_ctrl_c(endpoint: Endpoint) {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed listening to SIGINT");
+    endpoint.close().await;
 }
 
 /// Formats a [`SocketAddr`] so that console doesn't escape it.
@@ -732,78 +749,92 @@ async fn accept(
     discovery: Option<Box<dyn Discovery>>,
 ) -> anyhow::Result<()> {
     let endpoint = make_endpoint(secret_key.clone(), relay_map, discovery).await?;
-    let endpoints = endpoint.direct_addresses().initialized().await?;
-    let remote_addrs = endpoints
-        .iter()
-        .map(|endpoint| format!("--remote-endpoint {}", format_addr(endpoint.addr)))
-        .collect::<Vec<_>>()
-        .join(" ");
-    println!("Connect to this node using one of the following commands:\n");
-    println!(
-        "\tUsing the relay url and direct connections:\niroh-doctor connect {} {}\n",
-        secret_key.public(),
-        remote_addrs,
-    );
-    if let Some(relay_url) = endpoint.home_relay().get()? {
+
+    futures_lite::future::race(close_endpoint_on_ctrl_c(endpoint.clone()), async move {
+        let endpoints = endpoint
+            .direct_addresses()
+            .initialized()
+            .await
+            .expect("endpoint alive");
+
+        let remote_addrs = endpoints
+            .iter()
+            .map(|endpoint| format!("--remote-endpoint {}", format_addr(endpoint.addr)))
+            .collect::<Vec<_>>()
+            .join(" ");
+        println!("Connect to this node using one of the following commands:\n");
         println!(
-            "\tUsing just the relay url:\niroh-doctor connect {} --relay-url {}\n",
+            "\tUsing the relay url and direct connections:\niroh-doctor connect {} {}\n",
             secret_key.public(),
-            relay_url,
+            remote_addrs,
         );
-    }
-    if endpoint.discovery().is_some() {
-        println!(
-            "\tUsing just the node id:\niroh-doctor connect {}\n",
-            secret_key.public(),
-        );
-    }
-    let connections = Arc::new(AtomicU64::default());
-    while let Some(incoming) = endpoint.accept().await {
-        let connecting = match incoming.accept() {
-            Ok(connecting) => connecting,
-            Err(err) => {
-                warn!("incoming connection failed: {err:#}");
-                // we can carry on in these cases:
-                // this can be caused by retransmitted datagrams
-                continue;
-            }
-        };
-        let connections = connections.clone();
-        let endpoint = endpoint.clone();
-        tokio::task::spawn(async move {
-            let n = connections.fetch_add(1, portable_atomic::Ordering::SeqCst);
-            match connecting.await {
-                Ok(connection) => {
-                    if n == 0 {
-                        let Ok(remote_peer_id) = endpoint::get_remote_node_id(&connection) else {
-                            return;
-                        };
-                        println!("Accepted connection from {}", remote_peer_id);
-                        let t0 = Instant::now();
-                        let gui = Gui::new(endpoint.clone(), remote_peer_id);
-                        if let Ok(conn_type) = endpoint.conn_type(remote_peer_id) {
-                            log_connection_changes(gui.mp.clone(), remote_peer_id, conn_type);
-                        }
-                        let res = active_side(connection, &config, Some(&gui)).await;
-                        gui.clear();
-                        let dt = t0.elapsed().as_secs_f64();
-                        if let Err(cause) = res {
-                            eprintln!("Test finished after {dt}s: {cause}",);
-                        } else {
-                            eprintln!("Test finished after {dt}s",);
-                        }
-                    } else {
-                        // silent
-                        active_side(connection, &config, None).await.ok();
-                    }
-                }
-                Err(cause) => {
-                    eprintln!("error accepting connection {cause}");
+        if let Some(relay_url) = endpoint.home_relay().get().expect("endpoint alive") {
+            println!(
+                "\tUsing just the relay url:\niroh-doctor connect {} --relay-url {}\n",
+                secret_key.public(),
+                relay_url,
+            );
+        }
+        if endpoint.discovery().is_some() {
+            println!(
+                "\tUsing just the node id:\niroh-doctor connect {}\n",
+                secret_key.public(),
+            );
+        }
+        let connections = Arc::new(AtomicU64::default());
+        while let Some(incoming) = endpoint.accept().await {
+            let connecting = match incoming.accept() {
+                Ok(connecting) => connecting,
+                Err(err) => {
+                    warn!("incoming connection failed: {err:#}");
+                    // we can carry on in these cases:
+                    // this can be caused by retransmitted datagrams
+                    continue;
                 }
             };
-            connections.sub(1, portable_atomic::Ordering::SeqCst);
-        });
-    }
+            let connections = connections.clone();
+            let endpoint = endpoint.clone();
+            tokio::task::spawn(async move {
+                let n = connections.fetch_add(1, portable_atomic::Ordering::SeqCst);
+                match connecting.await {
+                    Ok(connection) => {
+                        if n == 0 {
+                            let Ok(remote_peer_id) = endpoint::get_remote_node_id(&connection)
+                            else {
+                                return;
+                            };
+                            println!("Accepted connection from {}", remote_peer_id);
+                            let t0 = Instant::now();
+                            let gui = Gui::new(endpoint.clone(), remote_peer_id);
+                            if let Ok(conn_type) = endpoint.conn_type(remote_peer_id) {
+                                log_connection_changes(gui.mp.clone(), remote_peer_id, conn_type);
+                            }
+                            let res = active_side(&connection, &config, Some(&gui)).await;
+                            gui.clear();
+                            let dt = t0.elapsed().as_secs_f64();
+                            if let Err(cause) = res {
+                                let close_reason = connection
+                                    .close_reason()
+                                    .map(|e| format!(" (reason: {})", e.to_string()))
+                                    .unwrap_or_default();
+                                eprintln!("Test finished after {dt}s: {cause}{close_reason}",);
+                            } else {
+                                eprintln!("Test finished after {dt}s",);
+                            }
+                        } else {
+                            // silent
+                            active_side(&connection, &config, None).await.ok();
+                        }
+                    }
+                    Err(cause) => {
+                        eprintln!("error accepting connection {cause}");
+                    }
+                };
+                connections.sub(1, portable_atomic::Ordering::SeqCst);
+            });
+        }
+    })
+    .await;
 
     Ok(())
 }


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->

Shows a close reason when the connection closes. E.g:
```
Test finished after 1.238599231s: connection lost (reason: closed by peer: 0)
```

This error message indicates that it's an *intentional* closing of the connection.
Otherwise it's something like:
```
Test finished after 1.238599231s: connection lost (reason: timed out)
```

This makes it easier to identify how the connection was lost.

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
Additionally, we ideally know if *we* closed the connection or if that was our peer. That info would be nice (but it's not as clear-cut, technically both could have closed the connection).
Also - using different error codes might be nice, but `Endpoint::close` doesn't support that yet. I'd like to at least separate a close from Ctrl+C with a close from e.g. a panic/Err.

## Change checklist

- [x] Self-review.
- ~~[ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.~~
- ~~[ ] Tests if relevant.~~
- [x] All breaking changes documented.
