### PR TITLE
chore: add patch for `iroh` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,8 +1883,7 @@ dependencies = [
 [[package]]
 name = "iroh"
 version = "0.90.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9436f319c2d24bca1b28a2fab4477c8d2ac795ab2d3aeda142d207b38ec068f4"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#9c023bf4d7d1c3c10a9cc3b10df7e1a22c6ab7a4"
 dependencies = [
  "aead",
  "backon",
@@ -1944,8 +1943,7 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "0.90.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0090050c4055b21e61cbcb856f043a2b24ad22c65d76bab91f121b4c7bece3"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#9c023bf4d7d1c3c10a9cc3b10df7e1a22c6ab7a4"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -2120,8 +2118,7 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "0.90.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f3cdbdaebc92835452e4e1d0d4b36118206b0950089b7bc3654f13e843475b"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#9c023bf4d7d1c3c10a9cc3b10df7e1a22c6ab7a4"
 dependencies = [
  "bytes",
  "cfg_aliases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,8 @@ webpki-roots = "0.26"
 [dev-dependencies]
 iroh-base = "0.90"
 url = "2.5.2"
+
+[patch.crates-io]
+iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+iroh-relay = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }

--- a/deny.toml
+++ b/deny.toml
@@ -1,36 +1,38 @@
+[advisories]
+ignore = ["RUSTSEC-2024-0370"]
+
 [bans]
-multiple-versions = "allow"
 deny = [
-     "aws-lc",
-     "aws-lc-rs",
-     "aws-lc-sys",
-     "native-tls",
-     "openssl",
+    "aws-lc",
+    "aws-lc-rs",
+    "aws-lc-sys",
+    "native-tls",
+    "openssl",
 ]
+multiple-versions = "allow"
 
 [licenses]
 allow = [
-      "Apache-2.0",
-      "Apache-2.0 WITH LLVM-exception",
-      "BSD-2-Clause",
-      "BSD-3-Clause",
-      "BSL-1.0", # BOSL license
-      "ISC",
-      "MIT",
-      "OpenSSL",
-      "Unicode-DFS-2016",
-      "Zlib",
-      "MPL-2.0", # https://fossa.com/blog/open-source-software-licenses-101-mozilla-public-license-2-0/
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "ISC",
+    "MIT",
+    "OpenSSL",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "MPL-2.0",
 ]
 
 [[licenses.clarify]]
-name = "ring"
 expression = "MIT AND ISC AND OpenSSL"
-license-files = [
-      { path = "LICENSE", hash = 0xbd0eed23 },
-]
+name = "ring"
 
-[advisories]
-ignore = [
-      "RUSTSEC-2024-0370", # unmaintained, no upgrade available
-]
+[[licenses.clarify.license-files]]
+hash = 3171872035
+path = "LICENSE"
+
+[sources]
+allow-git = ["https://github.com/n0-computer/iroh.git"]


### PR DESCRIPTION
This PR updates the following dependencies to use their main branches:

- `iroh` from `https://github.com/n0-computer/iroh.git`
- `iroh-base` from `https://github.com/n0-computer/iroh.git`
- `iroh-relay` from `https://github.com/n0-computer/iroh.git`
