### PR TITLE
chore: prep for 0.91.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1612,7 +1613,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1858,7 +1859,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.10",
  "widestring",
  "windows-sys 0.48.0",
  "winreg",
@@ -1883,7 +1884,7 @@ dependencies = [
 [[package]]
 name = "iroh"
 version = "0.90.0"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#9c023bf4d7d1c3c10a9cc3b10df7e1a22c6ab7a4"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#bcb60d42fecd79fcc5e4d064f410367a3f7aa0b2"
 dependencies = [
  "aead",
  "backon",
@@ -1892,7 +1893,7 @@ dependencies = [
  "crypto_box",
  "data-encoding",
  "der",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "ed25519-dalek",
  "futures-buffered",
  "futures-util",
@@ -1909,13 +1910,13 @@ dependencies = [
  "iroh-relay",
  "n0-future",
  "n0-snafu",
- "n0-watcher",
+ "n0-watcher 0.3.0",
  "nested_enum_utils",
- "netdev",
- "netwatch",
+ "netdev 0.36.0",
+ "netwatch 0.8.0",
  "pin-project",
  "pkarr 3.8.0",
- "portmapper",
+ "portmapper 0.8.0",
  "rand 0.8.5",
  "reqwest",
  "ring",
@@ -1926,7 +1927,7 @@ dependencies = [
  "smallvec",
  "snafu",
  "spki",
- "strum 0.26.3",
+ "strum 0.27.1",
  "stun-rs",
  "surge-ping",
  "time",
@@ -1943,11 +1944,11 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "0.90.0"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#9c023bf4d7d1c3c10a9cc3b10df7e1a22c6ab7a4"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#bcb60d42fecd79fcc5e4d064f410367a3f7aa0b2"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "ed25519-dalek",
  "n0-snafu",
  "nested_enum_utils",
@@ -1979,11 +1980,11 @@ dependencies = [
  "iroh-n0des",
  "iroh-quinn",
  "iroh-relay",
- "n0-watcher",
- "netwatch",
+ "n0-watcher 0.3.0",
+ "netwatch 0.6.0",
  "pkarr 2.3.1",
  "portable-atomic",
- "portmapper",
+ "portmapper 0.6.1",
  "postcard",
  "prometheus-client",
  "rand 0.8.5",
@@ -2073,7 +2074,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -2110,7 +2111,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2118,12 +2119,13 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "0.90.0"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#9c023bf4d7d1c3c10a9cc3b10df7e1a22c6ab7a4"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#bcb60d42fecd79fcc5e4d064f410367a3f7aa0b2"
 dependencies = [
+ "blake3",
  "bytes",
  "cfg_aliases",
  "data-encoding",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "getrandom 0.3.3",
  "hickory-resolver",
  "http 1.3.1",
@@ -2148,9 +2150,10 @@ dependencies = [
  "rustls-pki-types",
  "rustls-webpki",
  "serde",
+ "serde_bytes",
  "sha1",
  "snafu",
- "strum 0.26.3",
+ "strum 0.27.1",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -2475,6 +2478,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "n0-watcher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31462392a10d5ada4b945e840cbec2d5f3fee752b96c4b33eb41414d8f45c2a"
+dependencies = [
+ "derive_more 1.0.0",
+ "n0-future",
+ "snafu",
+]
+
+[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,6 +2527,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "netdev"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862209dce034f82a44c95ce2b5183730d616f2a68746b9c1959aa2572e77c0a1"
+dependencies = [
+ "dlopen2",
+ "ipnet",
+ "libc",
+ "netlink-packet-core",
+ "netlink-packet-route 0.22.0",
+ "netlink-sys",
+ "once_cell",
+ "system-configuration",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,9 +2570,39 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e7987b28514adf555dc1f9a5c30dfc3e50750bbaffb1aec41ca7b23dcd8e4"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.1",
+ "byteorder",
+ "libc",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0800eae8638a299eaa67476e1c6b6692922273e0f7939fd188fc861c837b9cd2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.1",
+ "byteorder",
+ "libc",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d83370a96813d7c977f8b63054f1162df6e5784f1c598d689236564fb5a6f2"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -2605,9 +2666,9 @@ dependencies = [
  "js-sys",
  "libc",
  "n0-future",
- "n0-watcher",
+ "n0-watcher 0.2.0",
  "nested_enum_utils",
- "netdev",
+ "netdev 0.31.0",
  "netlink-packet-core",
  "netlink-packet-route 0.23.0",
  "netlink-proto",
@@ -2615,7 +2676,7 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "snafu",
- "socket2",
+ "socket2 0.5.10",
  "time",
  "tokio",
  "tokio-util",
@@ -2623,7 +2684,42 @@ dependencies = [
  "web-sys",
  "windows 0.59.0",
  "windows-result",
- "wmi",
+ "wmi 0.14.5",
+]
+
+[[package]]
+name = "netwatch"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901dbb408894af3df3fc51420ba0c6faf3a7d896077b797c39b7001e2f787bd"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "cfg_aliases",
+ "derive_more 2.0.1",
+ "iroh-quinn-udp",
+ "js-sys",
+ "libc",
+ "n0-future",
+ "n0-watcher 0.3.0",
+ "nested_enum_utils",
+ "netdev 0.36.0",
+ "netlink-packet-core",
+ "netlink-packet-route 0.24.0",
+ "netlink-proto",
+ "netlink-sys",
+ "pin-project-lite",
+ "serde",
+ "snafu",
+ "socket2 0.6.0",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "web-sys",
+ "windows 0.61.3",
+ "windows-result",
+ "wmi 0.17.2",
 ]
 
 [[package]]
@@ -3109,13 +3205,44 @@ dependencies = [
  "iroh-metrics",
  "libc",
  "nested_enum_utils",
- "netwatch",
+ "netwatch 0.6.0",
  "num_enum",
  "rand 0.8.5",
  "serde",
  "smallvec",
  "snafu",
- "socket2",
+ "socket2 0.5.10",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "portmapper"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f1975debe62a70557e42b9ff9466e4890cf9d3d156d296408a711f1c5f642b"
+dependencies = [
+ "base64",
+ "bytes",
+ "derive_more 2.0.1",
+ "futures-lite",
+ "futures-util",
+ "hyper-util",
+ "igd-next",
+ "iroh-metrics",
+ "libc",
+ "nested_enum_utils",
+ "netwatch 0.8.0",
+ "num_enum",
+ "rand 0.9.1",
+ "serde",
+ "smallvec",
+ "snafu",
+ "socket2 0.6.0",
  "time",
  "tokio",
  "tokio-util",
@@ -3270,7 +3397,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -3307,7 +3434,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3877,6 +4004,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4105,6 +4241,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4267,7 +4413,7 @@ dependencies = [
  "parking_lot",
  "pnet_packet",
  "rand 0.9.1",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -4469,7 +4615,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -4524,9 +4670,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-websockets"
-version = "0.11.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fcaf159b4e7a376b05b5bfd77bfd38f3324f5fce751b4213bfc7eaa47affb4e"
+checksum = "3f29ba084eb43becc9864ba514b4a64f5f65b82f9a6ffbafa5436c1c80605f03"
 dependencies = [
  "base64",
  "bytes",
@@ -5064,7 +5210,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5555,6 +5701,21 @@ dependencies = [
  "thiserror 2.0.12",
  "windows 0.59.0",
  "windows-core 0.59.0",
+]
+
+[[package]]
+name = "wmi"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3de777dce4cbcdc661d5d18e78ce4b46a37adc2bb7c0078a556c7f07bcce2f"
+dependencies = [
+ "chrono",
+ "futures",
+ "log",
+ "serde",
+ "thiserror 2.0.12",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,20 @@
 version = 4
 
 [[package]]
+name = "acto"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a026259da4f1a13b4af60cda453c392de64c58c12d239c560923e0382f42f2b9"
+dependencies = [
+ "parking_lot",
+ "pin-project-lite",
+ "rustc_version",
+ "smol_str",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,8 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "0.90.0"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#bcb60d42fecd79fcc5e4d064f410367a3f7aa0b2"
+version = "0.91.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef05c956df0788a649d65c33fdbbb8fc4442d7716af3d67a1bd6d00a9ee56ead"
 dependencies = [
  "aead",
  "backon",
@@ -1930,6 +1945,7 @@ dependencies = [
  "strum 0.27.1",
  "stun-rs",
  "surge-ping",
+ "swarm-discovery",
  "time",
  "tokio",
  "tokio-stream",
@@ -1943,8 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "0.90.0"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#bcb60d42fecd79fcc5e4d064f410367a3f7aa0b2"
+version = "0.91.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f68b5c5e190d8965699b2fd583f301a7e6094a0b89bb4d6c5baa94761fd1b7a3"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -1981,7 +1998,7 @@ dependencies = [
  "iroh-quinn",
  "iroh-relay",
  "n0-watcher 0.3.0",
- "netwatch 0.6.0",
+ "netwatch 0.7.0",
  "pkarr 2.3.1",
  "portable-atomic",
  "portmapper 0.6.1",
@@ -2038,27 +2055,43 @@ dependencies = [
 
 [[package]]
 name = "iroh-n0des"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ffaf149d53894381a2b77d278990cd58c7c1bc243f53e313e1fd026bc4dffd"
+checksum = "00a9664caafd50e1bf311e9ae984de363941408ae20bd8bb03780a81fad307cc"
 dependencies = [
  "anyhow",
  "derive_more 2.0.1",
  "ed25519-dalek",
  "iroh",
  "iroh-metrics",
+ "iroh-n0des-macro",
+ "iroh-quinn",
  "irpc",
  "irpc-iroh",
  "n0-future",
  "rand 0.8.5",
  "rcan",
  "serde",
+ "serde_json",
  "ssh-key",
  "strum 0.27.1",
  "thiserror 2.0.12",
+ "time",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "iroh-n0des-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e15d38b6ae3d9480e49883bea72880f80d595276e34090f5096d844e6f7f5e40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2118,8 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "0.90.0"
-source = "git+https://github.com/n0-computer/iroh.git?branch=main#bcb60d42fecd79fcc5e4d064f410367a3f7aa0b2"
+version = "0.91.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49596b5079817d0904fe4985307f532a4e23a33eb494bd680baaf2743f0c456b"
 dependencies = [
  "blake3",
  "bytes",
@@ -2167,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "irpc"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b355fe12226ee885e1c1056a867c2cf37be2b22032a16f5ab7091069e98a966f"
+checksum = "a9f8f1d0987ea9da3d74698f921d0a817a214c83b2635a33ed4bc3efa4de1acd"
 dependencies = [
  "anyhow",
  "futures-buffered",
@@ -2190,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-derive"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efeabe1ee5615ea0416340b1a6d71a16f971495859c87fad48633b6497ee7a77"
+checksum = "3e0b26b834d401a046dd9d47bc236517c746eddbb5d25ff3e1a6075bfa4eebdb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2201,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-iroh"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9585893d9039f21e1406818d5bb3bc445ac4fa1b3aa2eb46a8bbd5963b11f77"
+checksum = "f5926531af491c6962db4d79f43ea219404cb800889922a728b1d3b92f887eda"
 dependencies = [
  "anyhow",
  "getrandom 0.3.3",
@@ -2685,6 +2719,41 @@ dependencies = [
  "windows 0.59.0",
  "windows-result",
  "wmi 0.14.5",
+]
+
+[[package]]
+name = "netwatch"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0445cbbb4d6d1afe22f4d1c14da2a2eb598a98b83650f15f988050bceefea5"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "cfg_aliases",
+ "derive_more 2.0.1",
+ "iroh-quinn-udp",
+ "js-sys",
+ "libc",
+ "n0-future",
+ "n0-watcher 0.2.0",
+ "nested_enum_utils",
+ "netdev 0.36.0",
+ "netlink-packet-core",
+ "netlink-packet-route 0.24.0",
+ "netlink-proto",
+ "netlink-sys",
+ "pin-project-lite",
+ "serde",
+ "snafu",
+ "socket2 0.6.0",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "web-sys",
+ "windows 0.61.3",
+ "windows-result",
+ "wmi 0.17.2",
 ]
 
 [[package]]
@@ -4209,6 +4278,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smol_str"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
+
+[[package]]
 name = "snafu"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4415,6 +4490,21 @@ dependencies = [
  "rand 0.9.1",
  "socket2 0.5.10",
  "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "swarm-discovery"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eae338a4551897c6a50fa2c041c4b75f578962d9fca8adb828cf81f7158740f"
+dependencies = [
+ "acto",
+ "hickory-proto",
+ "rand 0.9.1",
+ "socket2 0.5.10",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -4844,6 +4934,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4853,12 +4953,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ async-channel = "2.3.1"
 clap = { version = "4.5.20", features = ["derive"] }
 console = "0.15.8"
 crossterm = "0.28.1"
-derive_more = { version = "1.0.0", features = ["display"] }
+derive_more = { version = "1.0.0", features = ["display", "from_str"] }
 dirs-next = "2.0.0"
 futures-lite = "2.3.0"
 futures-util = "0.3"
@@ -26,7 +26,7 @@ iroh-metrics = { version = "0.35", features = ["service", "static_core"] }
 iroh-n0des = "0.1.0"
 iroh-relay = "0.90"
 netwatch = { version = "0.6" }
-n0-watcher = "0.2"
+n0-watcher = "0.3"
 pkarr = { version = "2.2.0", default-features = false }
 portable-atomic = "1.9.0"
 postcard = "1.0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ futures-lite = "2.3.0"
 futures-util = "0.3"
 hex = "0.4.3"
 indicatif = { version = "0.18", features = ["tokio"] }
-iroh = { version = "0.90", features = ["metrics"] }
+iroh = { version = "0.91", features = ["metrics"] }
 iroh-metrics = { version = "0.35", features = ["service", "static_core"] }
-iroh-n0des = "0.1.0"
-iroh-relay = "0.90"
-netwatch = { version = "0.6" }
+iroh-n0des = "0.2.0"
+iroh-relay = "0.91"
+netwatch = { version = "0.7" }
 n0-watcher = "0.3"
 pkarr = { version = "2.2.0", default-features = false }
 portable-atomic = "1.9.0"
@@ -52,10 +52,5 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 webpki-roots = "0.26"
 
 [dev-dependencies]
-iroh-base = "0.90"
+iroh-base = "0.91"
 url = "2.5.2"
-
-[patch.crates-io]
-iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
-iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
-iroh-relay = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }


### PR DESCRIPTION
## Description

upgrade to `iroh` v0.91.0, `n0_watcher` v0.3.0, `iroh-n0des` v0.2.0, `netwatch` v0.3